### PR TITLE
Add tests for Elasticsearch 7.9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        es: [7.8.1, 6.8.11]
+        es: [7.9.0, 7.8.1, 6.8.11]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ TARGET?=7.8.1
 # Handle new URL's:
 # https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.8.11.tar.gz
 # https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.8.1-linux-x86_64.tar.gz
-ifeq (7.8.1, ${TARGET})
-  TARGET_DOWNLOAD=${TARGET}-linux-x86_64
-else
+ifeq (6.8.11, ${TARGET})
   TARGET_DOWNLOAD=${TARGET}
+else
+  TARGET_DOWNLOAD=${TARGET}-linux-x86_64
 endif
 
 install: ## Download all the deps


### PR DESCRIPTION
Elasticsearch 7.9.0 has just been released, this PR add test for this version.